### PR TITLE
Duplicated file name in message box  description

### DIFF
--- a/livewebcam
+++ b/livewebcam
@@ -66,7 +66,7 @@ class TaskBarIcon(wx.adv.TaskBarIcon):
 
     def on_about(self, event):
         wx.MessageDialog(None, 'LiveWebcam will monitor your webcam activation and run the command or script of your choice: \n \
-            "~/bin/webcam_activated.sh" or "~/bin/webcam_activated.sh". \nBeware of security on those paths.', 'LiveWebcam Notification', wx.OK | wx.ICON_INFORMATION).ShowModal()
+            "~/bin/webcam_activated.sh" or "~/bin/webcam_deactivated.sh". \nBeware of security on those paths.', 'LiveWebcam Notification', wx.OK | wx.ICON_INFORMATION).ShowModal()
 
     def on_exit(self, event):
         wx.CallAfter(self.Destroy)


### PR DESCRIPTION
The description in the message box described that "webcam_activated.sh" or "webcam_activated.sh" was called but the second file name should have been webcam_deactivated.sh.